### PR TITLE
docs: GitHub Pages deploy workflow + README links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra docs
+
+      - name: Build docs
+        run: uv run mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+      - id: deployment
+        name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Asyncio-native Actor framework for Python agent systems — supervision trees, m
 
 Inspired by Erlang/Akka. Built for AI agent orchestration.
 
+**[Documentation](https://greatmengqi.github.io/actor-for-agents/)** · [Getting Started](https://greatmengqi.github.io/actor-for-agents/getting-started/) · [Agent Layer](https://greatmengqi.github.io/actor-for-agents/agents/) · [API Reference](https://greatmengqi.github.io/actor-for-agents/api/actor/)
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `.github/workflows/docs.yml` — builds MkDocs site and deploys to GitHub Pages on push to main
- Link README to docs site: Getting Started, Agent Layer, API Reference

## Note

Requires **Settings → Pages → Source → GitHub Actions** (already configured).

After merge, site will be live at https://greatmengqi.github.io/actor-for-agents/