### PR TITLE
docs: update agents.md and API reference with generic types

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -52,12 +52,12 @@ The agent layer has 5 levels. Start at the lowest level you need — upgrading l
 
 === "Level 4 — AgentActor"
 
-    Full power: supervision strategy, `emit_progress()`, access to actor context.
+    Full power: strong typing, supervision strategy, `emit_progress()`, access to actor context.
 
     ```python
     from actor_for_agents.agents import AgentActor
 
-    class SearchAgent(AgentActor):
+    class SearchAgent(AgentActor[str, str]):
         def supervisor_strategy(self):
             return OneForOneStrategy(max_restarts=5)
 
@@ -96,10 +96,10 @@ Every message to an `AgentActor` is a `Task`. The framework manages the lifecycl
 ```python
 from actor_for_agents.agents import Task, TaskResult, TaskStatus
 
-task = Task(input="what is the actor model?")
+task: Task[str] = Task(input="what is the actor model?")
 # task.id is auto-generated (uuid hex)
 
-result: TaskResult = await ref.ask(task)
+result: TaskResult[str] = await ref.ask(task)
 print(result.output)        # the value execute() returned
 print(result.status)        # TaskStatus.COMPLETED
 print(result.task_id)       # same as task.id
@@ -128,7 +128,7 @@ PENDING → RUNNING → COMPLETED
 | `task_started` | `execute()` begins |
 | `task_progress` | You call `emit_progress(data)` |
 | `task_completed` | `execute()` returns successfully |
-| `task_failed` | `execute()` raises an exception |
+| `task_failed` | `execute()` raises an exception (`data` contains the error message) |
 
 ```python
 @dataclass
@@ -148,7 +148,7 @@ Events flow to a `RunStream` when using `AgentSystem` (coming in M3). With plain
 Use `emit_progress()` inside `execute()` to stream intermediate results:
 
 ```python
-class StreamingAgent(AgentActor):
+class StreamingAgent(AgentActor[str, str]):
     async def execute(self, input: str) -> str:
         chunks = []
         async for token in llm.stream(input):

--- a/docs/api/agent-actor.md
+++ b/docs/api/agent-actor.md
@@ -8,18 +8,20 @@ from actor_for_agents.agents import Task
 
 A unit of work sent to an `AgentActor`.
 
+Generic type parameter `InputT` constrains the input type.
+
 **Fields**
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `input` | `Any` | required | The input data for the agent |
+| `input` | `InputT` | required | The input data for the agent |
 | `id` | `str` | auto (uuid hex) | Unique task identifier |
 
 **Example**
 
 ```python
-task = Task(input="summarize this document")
-task = Task(input={"query": "actor model", "limit": 5}, id="my-task-001")
+task: Task[str] = Task(input="summarize this document")
+task: Task[dict] = Task(input={"query": "actor model", "limit": 5}, id="my-task-001")
 ```
 
 ---
@@ -37,7 +39,7 @@ The outcome returned by `AgentActor.on_receive()` after `execute()` completes.
 | Field | Type | Description |
 |-------|------|-------------|
 | `task_id` | `str` | Matches the originating `Task.id` |
-| `output` | `Any` | The value returned by `execute()` |
+| `output` | `OutputT \| None` | The value returned by `execute()` |
 | `error` | `str \| None` | Error message if status is `FAILED` |
 | `status` | `TaskStatus` | `COMPLETED` or `FAILED` |
 
@@ -114,22 +116,29 @@ class MyAgent:
 from actor_for_agents.agents import AgentActor
 ```
 
-Base class for AI agents (Level 4). Inherits from `Actor`.
+Base class for AI agents (Level 4). Inherits from `Actor`. Generic over input type `InputT` and output type `OutputT`.
+
+```python
+class MyAgent(AgentActor[str, str]):
+    async def execute(self, input: str) -> str: ...
+```
+
+Type parameters flow end-to-end: `Task[InputT]` → `execute(input: InputT) -> OutputT` → `TaskResult[OutputT]`.
 
 ### Methods to override
 
 #### `execute(input)`
 
 ```python
-async def execute(self, input: Any) -> Any
+async def execute(self, input: InputT) -> OutputT
 ```
 
 Implement your agent logic here. The return value becomes `TaskResult.output`.
 
-Raise any exception to signal failure. The framework emits `task_failed` and supervision handles the restart.
+Raise any exception to signal failure. The framework emits `task_failed` (with the error message in `data`) and supervision handles the restart.
 
 ```python
-class SummaryAgent(AgentActor):
+class SummaryAgent(AgentActor[str, str]):
     async def execute(self, input: str) -> str:
         return await llm.summarize(input)
 ```
@@ -202,8 +211,8 @@ from actor_for_agents.agents import AgentActor, Task
 system = ActorSystem("app")
 ref = await system.spawn(SummaryAgent, "summarizer")
 
-result = await ref.ask(Task(input="..."))
-print(result.output)
+result: TaskResult[str] = await ref.ask(Task(input="..."))
+print(result.output)    # str
 print(result.status)    # TaskStatus.COMPLETED
 
 await system.shutdown()


### PR DESCRIPTION
Update docs to reflect `AgentActor[InputT, OutputT]` strong typing:

- `AgentActor[str, str]` in Level 4 example
- `Task[str]` / `TaskResult[str]` in Task lifecycle section
- `task_failed` event now mentions `data` contains error message
- API reference: `InputT`/`OutputT` type params, updated signatures

> ⚠️ Please wait until CI passes before merging.