### PR TITLE
docs: strong-type all AgentActor examples

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -174,8 +174,8 @@ class StreamingAgent(AgentActor[str, str]):
 - The `ask()` caller receives the exception
 
 ```python
-class FlakyAgent(AgentActor):
-    async def execute(self, input):
+class FlakyAgent(AgentActor[str, str]):
+    async def execute(self, input: str) -> str:
         if random.random() < 0.3:
             raise TransientError("try again")
         return process(input)
@@ -197,7 +197,7 @@ result = await ask_with_retry(
 If you accidentally override `on_receive()` in an `AgentActor` subclass, the framework emits a `UserWarning` at class definition time:
 
 ```python
-class MyAgent(AgentActor):
+class MyAgent(AgentActor[str, str]):
     async def on_receive(self, message):  # ← UserWarning
         ...
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,9 +40,9 @@ pip install actor-for-agents[redis]
 ```python
 import asyncio
 from actor_for_agents import ActorSystem
-from actor_for_agents.agents import AgentActor, Task
+from actor_for_agents.agents import AgentActor, Task, TaskResult
 
-class SummaryAgent(AgentActor):
+class SummaryAgent(AgentActor[str, str]):
     async def execute(self, input: str) -> str:
         await self.emit_progress("processing...")
         return f"Summary: {input[:50]}..."
@@ -51,7 +51,7 @@ async def main():
     system = ActorSystem("app")
     ref = await system.spawn(SummaryAgent, "summarizer")
 
-    result = await ref.ask(Task(input="Long document content here..."))
+    result: TaskResult[str] = await ref.ask(Task(input="Long document content here..."))
     print(result.output)  # Summary: Long document content here...
 
     await system.shutdown()


### PR DESCRIPTION
Strong-type remaining AgentActor examples in docs/index.md and docs/agents.md — FlakyAgent, MyAgent, SummaryAgent all use AgentActor[str, str].