### PR TITLE
docs: add design.md to mkdocs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
   - Getting Started: getting-started.md
   - Guides:
     - Agent Layer: agents.md
+    - Design: design.md
   - API Reference:
     - AgentActor: api/agent-actor.md
     - Core Actor: api/actor.md


### PR DESCRIPTION
Add Design page to Guides section in mkdocs navigation so it appears on the documentation site.