### PR TITLE
bench: add agent layer benchmarks and refresh numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,15 +190,30 @@ ref = await system.spawn(
 
 Apple M-series, Python 3.12, asyncio:
 
+**Actor core**
+
 | Metric | Value |
 |--------|-------|
-| `tell` throughput | 861K msg/s |
-| `ask` throughput | 20K msg/s |
-| `ask` latency p50 | 40 µs |
-| `ask` latency p99 | 262 µs |
-| 1000 actors × 100 msgs | 790K msg/s, 0 loss |
-| Middleware overhead | +6.3% (1 middleware) |
-| Spawn 5000 actors | 32 ms |
+| `tell` throughput | 945K msg/s |
+| `ask` throughput | 29K msg/s |
+| `ask` latency p50 | 32 µs |
+| `ask` latency p99 | 46 µs |
+| 100-hop actor chain | 2.0 ms, 20 µs/hop |
+| 1000 actors × 100 msgs | 879K msg/s, 0 loss |
+| Middleware overhead | +0% (~1 middleware) |
+| Spawn 5000 actors | 27 ms |
+
+**Agent layer**
+
+| Metric | Value |
+|--------|-------|
+| `AgentActor` ask throughput | 27K tasks/s |
+| `AgentActor` ask latency p50 | 36 µs |
+| `AgentActor` ask latency p99 | 50 µs |
+| `sequence(50)` fan-out | 32K child tasks/s |
+| `traverse(100)` map | 28K items/s |
+| `ask_stream` chunk throughput | 227K chunks/s |
+| `AgentSystem.run()` latency p50 | 0.2 ms (spawn+run+stream) |
 
 ## License
 

--- a/benchmarks/bench_agent.py
+++ b/benchmarks/bench_agent.py
@@ -1,0 +1,223 @@
+"""Agent layer benchmarks — Task round-trip, orchestration primitives, streaming."""
+
+import asyncio
+import time
+
+from actor_for_agents.agents import AgentActor, AgentSystem, Task
+
+
+def fmt(n):
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.0f}K"
+    return str(n)
+
+
+# ---------------------------------------------------------------------------
+# Agent fixtures
+# ---------------------------------------------------------------------------
+
+
+class EchoAgent(AgentActor[str, str]):
+    async def execute(self, input: str) -> str:
+        return input
+
+
+class UpperAgent(AgentActor[str, str]):
+    async def execute(self, input: str) -> str:
+        return input.upper()
+
+
+class ChunkAgent(AgentActor[str, list]):
+    """Yields n chunks per call — used for streaming benchmarks."""
+
+    async def execute(self, input: str):
+        n = int(input)
+        for i in range(n):
+            yield str(i)
+
+
+# ---------------------------------------------------------------------------
+# Benchmarks
+# ---------------------------------------------------------------------------
+
+
+async def bench_agent_ask_throughput(n=5_000):
+    """Task round-trip throughput through AgentActor."""
+    system = AgentSystem("bench")
+    ref = await system.spawn(EchoAgent, "echo")
+
+    # warmup
+    for _ in range(50):
+        await ref.ask(Task(input="w"))
+
+    start = time.perf_counter()
+    for _ in range(n):
+        await ref.ask(Task(input="ping"))
+    elapsed = time.perf_counter() - start
+
+    await system.shutdown()
+    rate = n / elapsed
+    print(f"  AgentActor ask throughput:  {fmt(n)} tasks in {elapsed:.2f}s = {fmt(int(rate))}/s")
+
+
+async def bench_agent_ask_latency(n=2_000):
+    """Task round-trip latency percentiles."""
+    system = AgentSystem("bench")
+    ref = await system.spawn(EchoAgent, "echo")
+
+    for _ in range(50):
+        await ref.ask(Task(input="w"))
+
+    latencies = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        await ref.ask(Task(input="ping"))
+        latencies.append((time.perf_counter() - t0) * 1_000_000)
+
+    await system.shutdown()
+    latencies.sort()
+    p50 = latencies[len(latencies) // 2]
+    p99 = latencies[int(len(latencies) * 0.99)]
+    print(f"  AgentActor ask latency:     p50={p50:.0f}µs  p99={p99:.0f}µs")
+
+
+async def bench_sequence(num_tasks=50, trials=20):
+    """sequence() fan-out: N concurrent ephemeral agents per call."""
+    system = AgentSystem("bench")
+
+    class OrchestratorAgent(AgentActor[str, list]):
+        async def execute(self, input: str) -> list:
+            n = int(input)
+            results = await self.context.sequence(
+                [(EchoAgent, Task(input=f"item-{i}")) for i in range(n)]
+            )
+            return [r.output for r in results]
+
+    ref = await system.spawn(OrchestratorAgent, "orch")
+
+    # warmup
+    await ref.ask(Task(input=str(num_tasks)))
+
+    start = time.perf_counter()
+    for _ in range(trials):
+        result = await ref.ask(Task(input=str(num_tasks)))
+        assert len(result.output) == num_tasks
+    elapsed = time.perf_counter() - start
+
+    await system.shutdown()
+    total_tasks = trials * num_tasks
+    rate = total_tasks / elapsed
+    print(
+        f"  sequence({num_tasks} agents):         {trials} calls in {elapsed:.2f}s "
+        f"= {fmt(int(rate))} child tasks/s"
+    )
+
+
+async def bench_traverse(n=100, trials=10):
+    """traverse(): map N inputs through one agent."""
+    system = AgentSystem("bench")
+
+    class OrchestratorAgent(AgentActor[str, list]):
+        async def execute(self, input: str) -> list:
+            k = int(input)
+            results = await self.context.traverse([f"item-{i}" for i in range(k)], UpperAgent)
+            return [r.output for r in results]
+
+    ref = await system.spawn(OrchestratorAgent, "orch")
+
+    await ref.ask(Task(input=str(n)))  # warmup
+
+    start = time.perf_counter()
+    for _ in range(trials):
+        result = await ref.ask(Task(input=str(n)))
+        assert len(result.output) == n
+    elapsed = time.perf_counter() - start
+
+    await system.shutdown()
+    rate = (trials * n) / elapsed
+    print(
+        f"  traverse({n} inputs):         {trials} calls in {elapsed:.2f}s "
+        f"= {fmt(int(rate))} items/s"
+    )
+
+
+async def bench_streaming(chunks=100, trials=20):
+    """ask_stream(): throughput of task_chunk events through AgentActor."""
+    from actor_for_agents.agents.task import StreamEvent, StreamResult
+
+    system = AgentSystem("bench")
+    ref = await system.spawn(ChunkAgent, "chunks")
+
+    # warmup
+    async for _ in ref.ask_stream(Task(input="10")):
+        pass
+
+    start = time.perf_counter()
+    total_chunks = 0
+    for _ in range(trials):
+        async for item in ref.ask_stream(Task(input=str(chunks))):
+            match item:
+                case StreamEvent(event=e) if e.type == "task_chunk":
+                    total_chunks += 1
+                case StreamResult():
+                    pass
+    elapsed = time.perf_counter() - start
+
+    await system.shutdown()
+    rate = total_chunks / elapsed
+    print(
+        f"  ask_stream({chunks} chunks):      {trials} calls in {elapsed:.2f}s "
+        f"= {fmt(int(rate))} chunks/s"
+    )
+
+
+async def bench_system_run(n=20):
+    """AgentSystem.run(): end-to-end event streaming overhead."""
+    system = AgentSystem("bench")
+
+    latencies = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        async for _ in system.run(EchoAgent, "hello"):
+            pass
+        latencies.append((time.perf_counter() - t0) * 1_000)
+
+    latencies.sort()
+    p50 = latencies[len(latencies) // 2]
+    p99 = latencies[int(len(latencies) * 0.99)]
+    print(f"  AgentSystem.run() latency:  p50={p50:.1f}ms  p99={p99:.1f}ms  (spawn+run+stream)")
+
+
+async def main():
+    print("=" * 60)
+    print("  Agent Layer Benchmarks")
+    print("=" * 60)
+    print()
+
+    print("[Task round-trip]")
+    await bench_agent_ask_throughput()
+    await bench_agent_ask_latency()
+    print()
+
+    print("[Orchestration primitives]")
+    await bench_sequence()
+    await bench_traverse()
+    print()
+
+    print("[Streaming]")
+    await bench_streaming()
+    print()
+
+    print("[AgentSystem.run]")
+    await bench_system_run()
+    print()
+
+    print("=" * 60)
+    print("  Done")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ asyncio.run(main())
 **Actor core**
 
 - `tell` (fire-and-forget) + `ask` (request-reply) messaging
-- `MemoryMailbox` — 861K msg/s throughput
+- `MemoryMailbox` — 945K msg/s throughput
 - `RedisMailbox` — persistent, survives process restarts
 - `OneForOneStrategy` / `AllForOneStrategy` supervision
 - Middleware pipeline for all lifecycle events
@@ -96,12 +96,25 @@ asyncio.run(main())
 
 ## Benchmarks
 
-Apple M-series, Python 3.12:
+Apple M-series, Python 3.12, asyncio:
+
+**Actor core**
 
 | Metric | Value |
 |--------|-------|
-| `tell` throughput | 861K msg/s |
-| `ask` throughput | 20K msg/s |
-| `ask` latency p50 | 40 µs |
-| Spawn 5000 actors | 32 ms |
-| Middleware overhead | +6.3% |
+| `tell` throughput | 945K msg/s |
+| `ask` throughput | 29K msg/s |
+| `ask` latency p50 | 32 µs |
+| `ask` latency p99 | 46 µs |
+| 1000 actors × 100 msgs | 879K msg/s, 0 loss |
+| Spawn 5000 actors | 27 ms |
+
+**Agent layer**
+
+| Metric | Value |
+|--------|-------|
+| `AgentActor` ask throughput | 27K tasks/s |
+| `AgentActor` ask latency p50 | 36 µs |
+| `sequence(50)` fan-out | 32K child tasks/s |
+| `ask_stream` chunk throughput | 227K chunks/s |
+| `AgentSystem.run()` latency p50 | 0.2 ms |


### PR DESCRIPTION
## Summary

- New `benchmarks/bench_agent.py` — agent layer benchmark suite covering:
  - `AgentActor` ask throughput and latency
  - `sequence()` fan-out (N concurrent ephemeral agents)
  - `traverse()` list mapping
  - `ask_stream()` chunk throughput
  - `AgentSystem.run()` end-to-end latency (spawn + run + stream)
- Updated README and `docs/index.md` benchmark tables with fresh measured numbers (Python 3.12, Apple M-series)

## New numbers

| Metric | Old | New |
|--------|-----|-----|
| `tell` throughput | 861K/s | 945K/s |
| `ask` throughput | 20K/s | 29K/s |
| `ask` latency p50 | 40 µs | 32 µs |
| Spawn 5000 | 32 ms | 27 ms |

## Test plan

- [ ] `python3.12 benchmarks/bench_agent.py` — all sections complete without error
- [ ] `python3.12 benchmarks/bench_actor.py` — all sections complete without error