### PR TITLE
chore: rename project to everything-is-an-actor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Coding principles for `actor-for-agents`. Follow these when writing or reviewing code in this repo.
+Coding principles for `everything-is-an-actor`. Follow these when writing or reviewing code in this repo.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 actor-for-agents contributors
+Copyright (c) 2025 everything-is-an-actor contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# actor-for-agents
+# everything-is-an-actor
 
 Asyncio-native Actor framework for Python agent systems — supervision trees, event streaming, and pluggable mailbox.
 
 Inspired by Erlang/Akka. Built for AI agent orchestration.
 
-**[Documentation](https://greatmengqi.github.io/actor-for-agents/)** · [Getting Started](https://greatmengqi.github.io/actor-for-agents/getting-started/) · [Agent Layer](https://greatmengqi.github.io/actor-for-agents/agents/) · [API Reference](https://greatmengqi.github.io/actor-for-agents/api/agent-actor/)
+**[Documentation](https://greatmengqi.github.io/everything-is-an-actor/)** · [Getting Started](https://greatmengqi.github.io/everything-is-an-actor/getting-started/) · [Agent Layer](https://greatmengqi.github.io/everything-is-an-actor/agents/) · [API Reference](https://greatmengqi.github.io/everything-is-an-actor/api/agent-actor/)
 
 ## Install
 
 ```bash
-pip install actor-for-agents
+pip install everything-is-an-actor
 
 # With Redis mailbox support
-pip install actor-for-agents[redis]
+pip install everything-is-an-actor[redis]
 ```
 
 ## Agent Quick Start

--- a/actor_for_agents/plugins/__init__.py
+++ b/actor_for_agents/plugins/__init__.py
@@ -1,6 +1,6 @@
-"""Optional plugins for actor-for-agents.
+"""Optional plugins for everything-is-an-actor.
 
-Redis mailbox (requires ``pip install actor-for-agents[redis]``)::
+Redis mailbox (requires ``pip install everything-is-an-actor[redis]``)::
 
     from actor_for_agents.plugins.redis import RedisMailbox
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,6 @@
 # Design
 
-Architecture overview and key design decisions for `actor-for-agents`.
+Architecture overview and key design decisions for `everything-is-an-actor`.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,13 +3,13 @@
 ## Installation
 
 ```bash
-pip install actor-for-agents
+pip install everything-is-an-actor
 ```
 
 For Redis mailbox support:
 
 ```bash
-pip install actor-for-agents[redis]
+pip install everything-is-an-actor[redis]
 ```
 
 Requirements: Python 3.12+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# actor-for-agents
+# everything-is-an-actor
 
 **Asyncio-native Actor framework for Python agent systems.**
 
@@ -6,7 +6,7 @@ Inspired by Erlang/Akka. Built for AI agent orchestration.
 
 ---
 
-## Why actor-for-agents?
+## Why everything-is-an-actor?
 
 Multi-agent AI systems have a concurrency problem. When a lead agent delegates to multiple workers, you need:
 
@@ -15,7 +15,7 @@ Multi-agent AI systems have a concurrency problem. When a lead agent delegates t
 - **Task lifecycle** — every unit of work has a status: pending → running → completed / failed
 - **Event streaming** — consumers subscribe to what agents produce, in real time
 
-The actor model solves all of these. `actor-for-agents` brings it to Python asyncio with two layers:
+The actor model solves all of these. `everything-is-an-actor` brings it to Python asyncio with two layers:
 
 | Layer | What it provides |
 |-------|-----------------|
@@ -27,10 +27,10 @@ The actor model solves all of these. `actor-for-agents` brings it to Python asyn
 ## Install
 
 ```bash
-pip install actor-for-agents
+pip install everything-is-an-actor
 
 # With Redis mailbox support
-pip install actor-for-agents[redis]
+pip install everything-is-an-actor[redis]
 ```
 
 ---

--- a/examples/redis_mailbox.py
+++ b/examples/redis_mailbox.py
@@ -1,6 +1,6 @@
 """Redis mailbox: durable inbox that survives process restarts.
 
-Requires: pip install actor-for-agents[redis]
+Requires: pip install everything-is-an-actor[redis]
 Requires: Redis running on localhost:6379
 """
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
-site_name: actor-for-agents
+site_name: everything-is-an-actor
 site_description: Asyncio-native Actor framework for Python agent systems
-site_url: https://greatmengqi.github.io/actor-for-agents
-repo_url: https://github.com/greatmengqi/actor-for-agents
-repo_name: actor-for-agents
+site_url: https://greatmengqi.github.io/everything-is-an-actor
+repo_url: https://github.com/greatmengqi/everything-is-an-actor
+repo_name: everything-is-an-actor
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "actor-for-agents"
+name = "everything-is-an-actor"
 version = "0.1.0"
 description = "Asyncio-native Actor framework for Python agent systems"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Rename the project from `actor-for-agents` to `everything-is-an-actor`.

### Changes
- Update package name in `pyproject.toml`
- Update all documentation references (README, docs, mkdocs.yml)
- Update LICENSE copyright
- Update CLAUDE.md coding principles reference

### Motivation
The new name better reflects the "everything is an actor" philosophy — a more inclusive and general-purpose name for the actor framework.