### PR TITLE
ci: add release workflow for PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - run: uv python install 3.12
+
+      - name: Build package
+        run: |
+          uv pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Add GitHub Actions workflow for publishing to PyPI when a version tag is pushed.

**Usage:**
```bash
git tag v0.1.0
git push origin v0.1.0
```

This will trigger the release workflow to build and publish the package to PyPI.