### PR TITLE
fix: use uv sync and uv run for build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
 
       - name: Build package
         run: |
-          uv pip install build
-          python -m build
+          uv sync --all-extras
+          uv run python -m build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Fix release workflow to use `uv sync` and `uv run python -m build` instead of bare `uv pip install build` which requires --system flag or venv.