### PR TITLE
fix: use Trusted Publishing with OIDC instead of API token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -25,4 +27,5 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
+          attestations: true
+          skip_existing: true


### PR DESCRIPTION
Switch from password-based upload to Trusted Publishing (OIDC).

**Changes:**
- Remove `PYPI_TOKEN` secret usage
- Add `permissions.id-token: write` for OIDC authentication
- Add `attestations: true` for package attestations
- Add `skip_existing: true` to skip already-existing versions

**Note:** To complete the setup, you need to add a Trusted Publisher in PyPI:
1. Go to https://pypi.org/manage/account/publishing/
2. Add a trusted publisher for this project
3. Configure: Owner (greatmengqi), Repo (everything-is-an-actor), Workflow (release.yml), Environment (release)